### PR TITLE
fixed node print

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -139,7 +139,7 @@ static void print_indent(unsigned level)
 {
     unsigned i;
     for (i = 0; i < level; i++) {
-        fprintf(stderr, " ");
+        fprintf(stderr, "   ");
     }
 }
 
@@ -159,7 +159,7 @@ static void Node_print2(Node *o, const char **tag_list, unsigned level)
         for (i = 0; i < len; i++) {
             Node *node = Node_get(o, i);
             assert(node != o);
-            print_indent(level + 1);
+            //print_indent(level + 1);
             if (node) {
                 Node_print2(node, tag_list, level + 1);
             }
@@ -169,9 +169,8 @@ static void Node_print2(Node *o, const char **tag_list, unsigned level)
             fprintf(stderr, "\n");
         }
         print_indent(level);
+        fprintf(stderr, "]");
     }
-    print_indent(level);
-    fprintf(stderr, "]");
 }
 
 void Node_print(Node *o, const char **tag_list)

--- a/src/node.c
+++ b/src/node.c
@@ -139,7 +139,7 @@ static void print_indent(unsigned level)
 {
     unsigned i;
     for (i = 0; i < level; i++) {
-        fprintf(stderr, "  ");
+        fprintf(stderr, " ");
     }
 }
 
@@ -166,11 +166,12 @@ static void Node_print2(Node *o, const char **tag_list, unsigned level)
             else {
                 fprintf(stderr, "null");
             }
-            fprintf(stderr, ",\n");
+            fprintf(stderr, "\n");
         }
         print_indent(level);
-        fprintf(stderr, "]");
     }
+    print_indent(level);
+    fprintf(stderr, "]");
 }
 
 void Node_print(Node *o, const char **tag_list)


### PR DESCRIPTION
mozでの出力結果がnezとほぼ同等の出力結果になるように、以下の修正を行いました。
1. Node表示の最後のコンマを削除
2. 括弧閉じ']'を'#'に合わせる

出力結果例：
tsunades-MacBook-Pro:build tsunade$ ./moz -p json.moz -i sample.json 
#JSON[
  #keyvalue[
    #String['key']
    #List[
      #Integer['12']
      #Integer['345']
    ]
  ]
]

ご確認お願い致します。