### PR TITLE
fixed Node_print2

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -139,7 +139,7 @@ static void print_indent(unsigned level)
 {
     unsigned i;
     for (i = 0; i < level; i++) {
-        fprintf(stderr, "  ");
+        fprintf(stderr, "   ");
     }
 }
 
@@ -159,14 +159,14 @@ static void Node_print2(Node *o, const char **tag_list, unsigned level)
         for (i = 0; i < len; i++) {
             Node *node = Node_get(o, i);
             assert(node != o);
-            print_indent(level + 1);
+            //print_indent(level + 1);
             if (node) {
                 Node_print2(node, tag_list, level + 1);
             }
             else {
                 fprintf(stderr, "null");
             }
-            fprintf(stderr, ",\n");
+            fprintf(stderr, "\n");
         }
         print_indent(level);
         fprintf(stderr, "]");


### PR DESCRIPTION
Node_print2にて、for文内の１６２行のprint_indent(level + 1);を削除しました。
nodeが存在するとき、Node_print2が呼び出されると、最初にインデントがプリントされますので（150行）、Node_print2を呼び出す前に、インデントをプリントする必要がないと思います。

実行結果：
tsunades-MacBook-Pro:nez tsunade$ java -jar nez.jar parse -p ../nez-sample/json.nez -i ../moz/build/sample.json 

#JSON[
   #keyvalue[
      #String['name']
      #String['Yokohama Tarou Jirou']
   ]
   #keyvalue[
      #String['age']
      #String['']
   ]
   #keyvalue[
      #String['titles']
      #List[
         #String['Yokohama']
         #String['National']
         #String['University']
      ]
   ]
   #keyvalue[
      #String['married']
      #False['false']
   ]
]

tsunades-MacBook-Pro:build tsunade$ ./moz -p json.moz -i sample.json 
#JSON[
   #keyvalue[
      #String['name']
      #String['Yokohama Tarou Jirou']
   ]
   #keyvalue[
      #String['age']
      #Integer['20']
   ]
   #keyvalue[
      #String['titles']
      #List[
         #String['Yokohama']
         #String['National']
         #String['University']
      ]
   ]
   #keyvalue[
      #String['married']
      #False['false']
   ]
]

使用ファイル：
nez-sample/json.nez
sample.json:
{
  "name": "Yokohama Tarou Jirou",
  "age": "20",
  "titles":[
    "Yokohama",
    "National",
    "University"
  ],
  "married": false
}